### PR TITLE
revert: update dependency conventional-changelog-conventionalcommits to v8

### DIFF
--- a/.release/package-lock.json
+++ b/.release/package-lock.json
@@ -15,7 +15,7 @@
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^10.0.0",
         "@semantic-release/release-notes-generator": "^13.0.0",
-        "conventional-changelog-conventionalcommits": "^8.0.0",
+        "conventional-changelog-conventionalcommits": "^7.0.2",
         "semantic-release": "^23.0.0"
       },
       "devDependencies": {
@@ -1123,14 +1123,14 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
-      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/.release/package.json
+++ b/.release/package.json
@@ -26,7 +26,7 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^10.0.0",
     "@semantic-release/release-notes-generator": "^13.0.0",
-    "conventional-changelog-conventionalcommits": "^8.0.0",
+    "conventional-changelog-conventionalcommits": "^7.0.2",
     "semantic-release": "^23.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts Hapag-Lloyd/rackspace-aws-login#10 because it breaks the release step