### PR TITLE
fix: reintroduces aws account id as parameter

### DIFF
--- a/.config/cspell.json
+++ b/.config/cspell.json
@@ -54,6 +54,7 @@
     "signoff",
     "stty",
     "venv",
-    "vuln"
+    "vuln",
+    "curr"
   ]
 }


### PR DESCRIPTION
# Description

It was previously possible to call the aws_login function with an aws account id as a parameter. This PR reintroduces this functionality. The Account ID must be found within the aws_accounts.txt file, otherwise it is unknown in rackspace and thus the login fails.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
