### PR TITLE
fix: always fetch rackspace token and tenant

### DIFF
--- a/aws_login.sh
+++ b/aws_login.sh
@@ -21,8 +21,15 @@ function aws_login() {
   local rackspace_username
   local rackspace_api_key
 
+  temporary_rackspace_token=""
+  rackspace_tennant_id=""
+  rackspace_username=""
+  rackspace_api_key=""
+
   function get_aws_accounts_from_rackspace() {
-    get_rackspace_token_and_tenant
+    if [ -z "$temporary_rackspace_token" ]; then
+      get_rackspace_token_and_tenant
+    fi
 
     aws_accounts=$(curl --location 'https://accounts.api.manage.rackspace.com/v0/awsAccounts' \
       --silent \

--- a/aws_login.sh
+++ b/aws_login.sh
@@ -22,9 +22,7 @@ function aws_login() {
   local rackspace_api_key
 
   function get_aws_accounts_from_rackspace() {
-    if [ -z "$temporary_rackspace_token" ]; then
-      get_rackspace_token_and_tenant
-    fi
+    get_rackspace_token_and_tenant
 
     aws_accounts=$(curl --location 'https://accounts.api.manage.rackspace.com/v0/awsAccounts' \
       --silent \


### PR DESCRIPTION
# Description

When executing the script, it should always fetch new temporary rackspace credentials. This fixes an error message indicating unused local variables.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
